### PR TITLE
Fix packet length check in _update()

### DIFF
--- a/adafruit_ble_apple_media.py
+++ b/adafruit_ble_apple_media.py
@@ -95,7 +95,7 @@ class _MediaAttribute:
             obj._buffer = bytearray(128)
         length_read = obj._entity_update.readinto(obj._buffer)
         if length_read > 0:
-            if length_read < 4:
+            if length_read < 3:
                 raise RuntimeError("packet too short")
             # Even though flags is currently unused, if it were removed, it would cause there to be
             # too many values to unpack which would raise a ValueError


### PR DESCRIPTION
Fixes #8 by submitting the fixed proposed by @tannewt in the issue

Seems like the number of items to check in the buffer was set too high, but want to learn more about this error for my own sake if anyone knows!